### PR TITLE
Fix double quotes bug in tag filtering

### DIFF
--- a/apps/web/app/blog/components/BlogFilters.tsx
+++ b/apps/web/app/blog/components/BlogFilters.tsx
@@ -71,7 +71,7 @@ export default function BlogFilters({ availableTags, posts }: BlogFiltersProps) 
                                 {tagMeta.label}
                             </Button>
                         )
-                    })}''
+                    })}
                 </div>
 
                 {selectedTags.length > 0 && (


### PR DESCRIPTION
## Summary
- Removes extra single quotes (`''`) at the end of the tag filter map function in BlogFilters.tsx
- Fixes display bug where double quotes were appearing in the tag filtering UI

## Changes
- Fixed line 74 in `app/blog/components/BlogFilters.tsx` by removing the extra quotes after `})}` 

## Test plan
- [ ] Verify tag filtering buttons display correctly without extra quotes
- [ ] Confirm tag filtering functionality still works as expected
- [ ] Check that no other UI elements are affected

🤖 Generated with [Claude Code](https://claude.ai/code)