### PR TITLE
Fix duplicate title in Claude Code thinking levels blog post

### DIFF
--- a/apps/web/blogs/CLAUDE.md
+++ b/apps/web/blogs/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md - Blog Post Guidelines
+
+This file provides guidance to Claude Code when working with blog posts in this directory.
+
+## Blog Post Structure
+
+### Title Guidelines - CRITICAL
+
+**DO NOT** include H1 titles (`# Title`) in the MDX content. The blog post page template automatically renders the title from the metadata object.
+
+**Correct Structure:**
+```mdx
+import { BLOG_TAGS } from '@/lib/blog-tags'
+
+export const metadata = {
+  title: 'Your Blog Post Title',
+  description: 'Description of your post',
+  date: '2025-01-01T12:00:00Z',
+  tags: [BLOG_TAGS.EXAMPLE_TAG],
+}
+
+Your content starts here directly without a duplicate H1 title.
+
+## Your First Section Header
+
+Content goes here...
+```
+
+**Incorrect Structure (DO NOT DO THIS):**
+```mdx
+import { BLOG_TAGS } from '@/lib/blog-tags'
+
+export const metadata = {
+  title: 'Your Blog Post Title',
+  description: 'Description of your post',
+  date: '2025-01-01T12:00:00Z',
+  tags: [BLOG_TAGS.EXAMPLE_TAG],
+}
+
+# Your Blog Post Title  <!-- DO NOT DO THIS - Creates duplicate title -->
+
+Your content starts here...
+```
+
+### Required Elements
+
+1. **Import statement** for BLOG_TAGS
+2. **Metadata export** with:
+   - `title`: The blog post title (will be rendered by page template)
+   - `description`: SEO description
+   - `date`: ISO date string
+   - `tags`: Array using BLOG_TAGS constants only
+
+### Content Guidelines
+
+- Start content directly after metadata export
+- Use H2 (`##`) for main section headers
+- Use H3 (`###`) for subsections
+- All tags must be defined in `@/lib/blog-tags.ts`
+- Follow existing blog post patterns for consistency
+
+### Why No H1 Titles?
+
+The blog post page template (`app/blog/[slug]/page.tsx`) automatically renders:
+- The title from metadata as an H1
+- The formatted date
+- The tags with proper styling
+- Navigation breadcrumbs
+
+Adding an H1 in the MDX content creates a duplicate title display.

--- a/apps/web/blogs/claude-code-thinking-levels-ultrathink.mdx
+++ b/apps/web/blogs/claude-code-thinking-levels-ultrathink.mdx
@@ -9,8 +9,6 @@ export const metadata = {
   abstract: 'An exploration of Claude Code\'s thinking budget system and how specific phrases unlock progressively more computational resources for better problem-solving.',
 }
 
-# Unlocking Claude Code's Hidden Thinking Levels: From 'Think' to 'Ultrathink'
-
 What if I told you that saying "ultrathink" to Claude Code isn't just a quirky way to ask for better results—it's actually a hard-coded feature that unlocks maximum computational thinking budget? 
 
 When I first learned about Claude Code's thinking levels during an Anthropic training course, I thought it sounded too good to be true. Phrases like "think harder" and "ultrathink" seemed more like developer humor than actual features. But after digging deeper and finding technical verification through a Hacker News thread, I discovered that these aren't just magical incantations—they're real system commands that fundamentally change how Claude Code approaches your problems.


### PR DESCRIPTION
## Summary
- Remove duplicate H1 title from `claude-code-thinking-levels-ultrathink.mdx` that was causing the title to appear twice
- Add `CLAUDE.md` file in blogs directory with comprehensive guidelines to prevent future duplicate title issues

## Test plan
- [x] Run development server to verify blog post displays correctly
- [x] Run `pnpm run lint` - all checks passed
- [x] Run `pnpm run check-types` - all checks passed
- [x] Verify the blog post now shows title only once (from metadata)

🤖 Generated with [Claude Code](https://claude.ai/code)