### PR TITLE
Fix GPT-5 launch date in aquarium blog post

### DIFF
--- a/apps/web/blogs/gpt5-vs-claude-code-3d-aquarium-comparison.mdx
+++ b/apps/web/blogs/gpt5-vs-claude-code-3d-aquarium-comparison.mdx
@@ -9,7 +9,7 @@ export const metadata = {
   abstract: 'Launch day test: GPT-5 (Cursor) vs Claude Code (Sonnet 4) building the same 3D aquarium. Same models, different results.',
 }
 
-Today's a big day — **August 8, 2025** — the day GPT-5 officially dropped.  
+Today's a big day — **Aug 7, 2025** — the day GPT-5 officially dropped.  
 
 Naturally, I had to test it. But instead of a quick coding prompt, I decided to run it through the same **one-shot challenge** I gave Claude Code (Sonnet 4): build a detailed 3D aquarium app.
 


### PR DESCRIPTION
## Summary
Fix incorrect GPT-5 launch date in the aquarium comparison blog post.

## Change
- **Before**: "Today's a big day — **August 8, 2025** — the day GPT-5 officially dropped."
- **After**: "Today's a big day — **Aug 7, 2025** — the day GPT-5 officially dropped."

## Context
This corrects a factual error in the recently merged blog post. The launch day narrative should reference the correct date to maintain accuracy.

## Files Changed
- `apps/web/blogs/gpt5-vs-claude-code-3d-aquarium-comparison.mdx` (single line correction)

🤖 Generated with [Claude Code](https://claude.ai/code)