### PR TITLE
Fix open graph images for social media sharing

### DIFF
--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getBlogPosts } from "@/utils/getBlogPost"
 import { TAG_METADATA } from "@/lib/blog-tags"
 import Link from "next/link"
 import { Header } from "@/components/header"
+import { Metadata } from "next"
 
 
 type BlogPageProps = {
@@ -13,6 +14,41 @@ type BlogPostMetadata = {
     description: string
     date: string
     tags: string[]
+}
+
+export async function generateMetadata({ params }: BlogPageProps): Promise<Metadata> {
+    const { slug } = await params
+    const post = await import(`@/blogs/${slug}.mdx`)
+    const metadata: BlogPostMetadata = post.metadata
+
+    return {
+        title: metadata.title,
+        description: metadata.description,
+        openGraph: {
+            title: metadata.title,
+            description: metadata.description,
+            url: `https://mauricioacosta.dev/blog/${slug}`,
+            siteName: "Mauricio Acosta Personal Website",
+            images: [
+                {
+                    url: "https://mauricioacosta.dev/apple-touch-icon.png",
+                    width: 180,
+                    height: 180,
+                    alt: metadata.title,
+                },
+            ],
+            locale: "en_US",
+            type: "article",
+            publishedTime: metadata.date,
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: metadata.title,
+            description: metadata.description,
+            images: ["https://mauricioacosta.dev/apple-touch-icon.png"],
+            creator: "@mauricioTechDev",
+        },
+    }
 }
 
 export default async function BlogPage({ params }: BlogPageProps) {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -24,9 +24,9 @@ export const metadata: Metadata = {
     siteName: "Mauricio Acosta Personal Website",
     images: [
       {
-        url: "https://mauricioacosta.dev/og-image.png",
-        width: 1200,
-        height: 630,
+        url: "https://mauricioacosta.dev/apple-touch-icon.png",
+        width: 180,
+        height: 180,
         alt: "Mauricio Acosta Personal Website",
       },
     ],
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Mauricio Acosta Personal Website",
     description: "The personal website of Mauricio Acosta, a software engineer.",
-    images: ["https://mauricioacosta.dev/og-image.png"],
+    images: ["https://mauricioacosta.dev/apple-touch-icon.png"],
     creator: "@mauricioTechDev",
   }
 };


### PR DESCRIPTION
## Summary
- Replace non-existent `og-image.png` with existing `apple-touch-icon.png` in root layout
- Add `generateMetadata` function to blog posts for dynamic open graph metadata
- Each blog post now has specific title, description, and image when shared on social media

## Problem Solved
When sharing blog posts on Twitter/social media, no image was appearing because the root layout referenced a non-existent `og-image.png` file. Individual blog posts also lacked specific open graph metadata.

## Test plan
- [ ] Verify that social media sharing tools show the apple-touch-icon.png image
- [ ] Test that individual blog posts have their specific titles and descriptions when shared
- [ ] Confirm that the root layout fallback now works correctly
- [ ] Run type checking and linting (already passed)

🤖 Generated with [Claude Code](https://claude.ai/code)